### PR TITLE
fix: f-string expression part cannot include a backslash

### DIFF
--- a/src/caioh_nvml_gpu_control/helper_functions.py
+++ b/src/caioh_nvml_gpu_control/helper_functions.py
@@ -258,7 +258,7 @@ def fan_control_subroutine(gpu_handle, configuration):
 
             # Only print log messages when necessary to avoid taking too much disk space
             if configuration.verbose == True or setting_changed == True:
-                log_helper(f'{"\n" + "\n".join(log_msg) + "\n"}')
+                log_helper("\n" + "\n".join(log_msg) + "\n")
 
             # Match found and set, return now
             return
@@ -391,7 +391,7 @@ def power_control_subroutine(gpu_handle, target_power_limit, dry_run, verbose):
 
     # Only print log messages when necessary to avoid taking too much disk space
     if verbose == True or setting_changed == True:
-        log_helper(f'{"\n" + "\n".join(log_msg) + "\n"}')
+        log_helper("\n" + "\n".join(log_msg) + "\n")
 
 # Temperature control
 
@@ -479,7 +479,7 @@ def temp_control_subroutine(gpu_handle, target_acoustic_temp_limit, dry_run, ver
 
     # Only print log messages when necessary to avoid taking too much disk space
     if verbose == True or setting_changed == True:
-        log_helper(f'{"\n" + "\n".join(log_msg) + "\n"}')
+        log_helper("\n" + "\n".join(log_msg) + "\n")
 
 
 def control_all(configuration):


### PR DESCRIPTION
f-string and string concat is redundant and `\n` causes issues on older versions of python (I'm getting this on Python 3.13.5).

```
Traceback (most recent call last):
  File "/root/.local/bin/chnvml", line 3, in <module>
    from caioh_nvml_gpu_control.__main__ import script_call
  File "/root/.local/pipx/venvs/caioh-nvml-gpu-control/lib/python3.11/site-packages/caioh_nvml_gpu_control/__main__.py", line 9, in <module>
    import nvml_gpu_control
  File "/root/.local/pipx/venvs/caioh-nvml-gpu-control/lib/python3.11/site-packages/caioh_nvml_gpu_control/nvml_gpu_control.py", line 3, in <module>
    import helper_functions as main_funcs
  File "/root/.local/pipx/venvs/caioh-nvml-gpu-control/lib/python3.11/site-packages/caioh_nvml_gpu_control/helper_functions.py", line 261
    log_helper(f'{"\n" + "\n".join(log_msg) + "\n"}')
                                                    ^
SyntaxError: f-string expression part cannot include a backslash
```